### PR TITLE
test用のファイル作成

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -62,6 +62,26 @@ return [
             ]) : [],
         ],
 
+         'mysql_testing' => [
+            'driver' => 'mysql',
+            'url' => env('DB_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE', 'my_laravel_app_test'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => env('DB_CHARSET', 'utf8mb4'),
+            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
         'mariadb' => [
             'driver' => 'mariadb',
             'url' => env('DB_URL'),

--- a/tests/Feature/MTeamTest.php
+++ b/tests/Feature/MTeamTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\MTeam;
+
+class MTeamTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     */
+
+    use RefreshDatabase;
+    
+    /** @test */
+    public function チームを一件登録できる()
+    {
+      $response = MTeam::create([
+        'name' => 'テストチーム'
+      ]);
+
+      $this->assertDatabaseHas('m_teams',[
+        'name' => 'テストチーム'
+      ]);
+    }
+
+    /** @test */
+    public function チーム一覧を取得できる()
+    {
+        MTeam::create(['name' => 'Aチーム']);
+        MTeam::create(['name' => 'Bチーム']);
+
+        $teams = MTeam::all();
+
+        $this->assertCount(2, $teams);
+        $this->assertEquals('Aチーム', $teams[0]->name);
+    }
+
+    /** @test */
+    public function チーム作成APIにアクセスすると登録される()
+    {
+        $response = $this->get('/teams/create');
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('m_teams', ['name' => '阪神タイガース']);
+    }
+}


### PR DESCRIPTION
Testファイルの作成
php artisan make:test MTeamTest

テスト実行コマンド
php artisan test

.env .testingのConnection情報は本番と分ける
create database
↓
config/database.phpの編集
↓
php artisan migrate --env=testing
↓上手くいかないときは一度リフレッシュ
php artisan migrate:fresh --env=testing

php artisan test
