### PR TITLE
お気に入り機能の実装

### DIFF
--- a/app/Models/TPlayer.php
+++ b/app/Models/TPlayer.php
@@ -50,4 +50,8 @@ class TPlayer extends Model
 
     use SoftDeletes;
     protected $dates = ['deleted_at'];
+
+    public function favoredByUsers (){
+        return $this->belongsToMany(User::class, 't_favorite_players', 'player_id', 'user_id')->withTimestamps();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,4 +45,8 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function favoritePlayers(){
+        return $this->belongsToMany(TPlayer::class, 't_favorite_players', 'user_id', 'player_id')->withTimestamps();
+    }
 }

--- a/database/migrations/2025_06_06_004445_create_favorite_players_table.php
+++ b/database/migrations/2025_06_06_004445_create_favorite_players_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('t_favorite_players', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('player_id')->constrained('t_players')->onDelete('cascade');
+            $table->timestamps();
+        
+            $table->unique(['user_id', 'player_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('t_favorite_players');
+    }
+};

--- a/resources/js/Pages/Players/Show.vue
+++ b/resources/js/Pages/Players/Show.vue
@@ -17,6 +17,25 @@ const destroy = () => {
         }));
     }
 };
+
+const toggleFavorite = async () => {
+  try {
+    const response = await fetch(route('players.favorite', {team_id: props.team.id, player_id: props.player.id }), {
+      method: 'POST',
+      headers: {
+        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        'Accept': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+    props.player.is_favorite = data.is_favorite;
+
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 </script>
 
 <template>
@@ -54,6 +73,9 @@ const destroy = () => {
                     </tr>
                 </tbody>
             </table>
+            <button @click="toggleFavorite" :disabled="form.processing">
+                {{ props.player.is_favorite ? '★ お気に入り' : '☆ お気に入りに追加' }}
+            </button><br />
             <Link :href="route('players.edit', {'team_id': props.team.id, 'player_id': props.player.id})">編集</Link><br />
             <button @click="destroy" :disabled="form.processing">削除</button><br />
             <Link :href="route('players.index', {'team_id': props.team.id})">戻る</Link><br />

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title inertia>{{ config('app.name', 'Laravel') }}</title>
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        <!-- Scripts -->
+        @routes
+        @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
+        @inertiaHead
+    </head>
+    <body class="font-sans antialiased">
+        @inertia
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,5 +48,6 @@ Route::put('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'u
 Route::delete('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'destroy'])->name('players.destroy');
 Route::post('/teams/{team_id}/players/{player_id}/restore', [TPlayerController::class, 'restore'])->name('players.restore');
 
+Route::post('/teams/{team_id}/players/{player_id}/favorite', [TPlayerController::class, 'toggleFavorite'])->middleware('auth')->name('players.favorite');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
**・多対多のお気に入りリレーションロジック実装**
- users と players を t_favorite_players テーブルで多対多関連付け
- User モデルに favoritePlayers()
- TPlayer モデルに favoredByUsers()


**・Controllerファイルの修正**
- `TPlayerController@show` にて、ログインユーザーがお気に入り登録済みかどうかを判定するロジックを追加
- `toggleFavorite` メソッドを追加し、お気に入りの登録／解除を切り替える機能を実装

**・t_favorite_players テーブルのマイグレーション追加**

- ユーザーと選手（TPlayer）の多対多リレーションを保持する中間テーブルを作成

**・Vue 画面の修正（Show.vue）**

- お気に入りボタンの追加
- ボタンクリックで toggleFavorite API を呼び出し、リアルタイムで状態を反映

**・ルーティングの追加**

- `/teams/{team_id}/players/{player_id}/favorite` に POST メソッドを追加し、お気に入り登録・解除をコントローラー経由で実行
