### PR TITLE
お気に入り選手の画面をvueで作成

### DIFF
--- a/app/Http/Controllers/TFavoriteController.php
+++ b/app/Http/Controllers/TFavoriteController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\TFavorite;
+use Inertia\Inertia;
+use Illuminate\Support\Facades\Auth;
+
+class TFavoriteController extends Controller
+{
+    //
+    public function index(){
+        $user = Auth::user();
+
+        $players = $user->favoritePlayers()
+        ->with('team')
+        ->get();
+
+        return Inertia::render('Players/Favorites', [ 'players' => $players ]);
+    }
+}

--- a/app/Models/TFavorite.php
+++ b/app/Models/TFavorite.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TFavorite extends Model
+{
+    //
+}

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -23,7 +23,8 @@ import { Head, Link } from '@inertiajs/vue3';
                     <div class="p-6 text-gray-900">
                         You're logged in!
                         <h1>プロ野球選手名鑑</h1>
-                        <Link :href="route('teams.index')">球団一覧</Link>
+                        <Link :href="route('teams.index')">球団一覧</Link><br />
+                        <Link :href="route('favorites.index')">お気に入り選手一覧</Link><br />
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Players/Favorites.vue
+++ b/resources/js/Pages/Players/Favorites.vue
@@ -1,0 +1,35 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    players: Array,
+});
+
+</script>
+
+<template>
+    <Head title="お気に入り選手一覧" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h1 class="text-xl font-bold">お気に入り選手一覧</h1>
+        </template>
+        <div>
+            <table border="1" cellpadding="5">
+                <thead>
+                    <tr>
+                        <th>名前</th>
+                        <th>チーム</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="player in props.players" :key="player.id">
+                        <td>{{ player.name}}</td>
+                        <td>{{ player.team.name }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <Link :href="route('dashboard')">トップページへ戻る</Link><br />
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Players/Index.vue
+++ b/resources/js/Pages/Players/Index.vue
@@ -42,6 +42,7 @@ const props = defineProps({
             </table>
             <Link :href="route('players.deleted', { team_id: props.team.id})">削除選手ページ遷移</Link><br /> 
             <Link :href="route('teams.show', { team_id: props.team.id})">戻る</Link><br /> 
+            <Link :href="route('favorites.index')">お気に入り選手一覧</Link><br />
             <Link :href="route('dashboard')">トップページ</Link>
         </div>
     </AuthenticatedLayout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\MTeamController;
 use App\Http\Controllers\MPlayerController;
 use App\Http\Controllers\TPlayerController;
+use App\Http\Controllers\TFavoriteController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -49,5 +50,6 @@ Route::delete('/teams/{team_id}/players/{player_id}', [TPlayerController::class,
 Route::post('/teams/{team_id}/players/{player_id}/restore', [TPlayerController::class, 'restore'])->name('players.restore');
 
 Route::post('/teams/{team_id}/players/{player_id}/favorite', [TPlayerController::class, 'toggleFavorite'])->middleware('auth')->name('players.favorite');
+Route::get('/favorites', [TFavoriteController::class, 'index'])->middleware('auth')->name('favorites.index');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 概要

ユーザーがお気に入り登録した選手の一覧を表示するページを追加。

## 変更内容

- `/favorites` ルートを新規追加
- `FavoriteController@index` を作成し、ログインユーザーのお気に入り選手を取得
- Inertia + Vue でお気に入り選手一覧画面を作成
  - 選手名とチーム名を表示
  - ダッシュボードに戻るリンクを追加

## 補足

- 選手情報にはリレーション `team` を含めています（`with('team')`）
- 戻るリンクは Ziggy 経由で `route('dashboard')` を指定しています
