### PR TITLE
UIを統一し選手関連画面のデザインを改善（一覧・詳細・編集・作成・削除・お気に入り・トップページ）

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -33,6 +33,8 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
+        session()->flash('status', 'ログインに成功しました！');
+
         return redirect()->intended(route('dashboard', absolute: false));
     }
 

--- a/app/Http/Controllers/TPlayerController.php
+++ b/app/Http/Controllers/TPlayerController.php
@@ -30,7 +30,7 @@ class TPlayerController extends Controller
         return Inertia::render('Players/Create', ['team' => $team, 'positions' => $positions, 'prefectures' => $prefectures, 'citys' => $citys]);
     }
 
-    public function store(Request $request, $team_id){
+    public function store(Request $request, $team_id){      
         //バリテーション
         $validated  = $request->validate([
             'name' => 'required|string|max:255',
@@ -38,13 +38,14 @@ class TPlayerController extends Controller
             'uniform_no' => 'required|string|max:10',
             'highschool' => 'nullable|string|max:255',
             'university' => 'nullable|string|max:255',
-            'birthday' => 'nullable|string|max:255',
+            'birthday' => 'required|date',
             'prefecture_id' => 'nullable|integer|max:47',
             'city_id' => 'nullable|integer|max:1892',
         ]);
 
         //team_idは固定なので後から追加
         $validated['team_id'] = $team_id;
+        $validated['birthday'] = \Carbon\Carbon::parse($validated['birthday'])->format('Y年m月d日');
 
         TPlayer::create($validated);
 
@@ -70,7 +71,7 @@ class TPlayerController extends Controller
         $player = TPlayer::with(['position', 'team', 'prefecture', 'city'])
             ->where('team_id', $team_id)
             ->findOrFail($player_id);
-        
+            
         $team = MTeam::findOrFail($team_id);
 
         $positions = MPosition::all();
@@ -89,10 +90,12 @@ class TPlayerController extends Controller
             'uniform_no' => 'required|string|max:10',
             'highschool' => 'nullable|string|max:255',
             'university' => 'nullable|string|max:255',
-            'birthday' => 'nullable|string|max:255',
+            'birthday' => 'nullable|date',
             'prefecture_id' => 'nullable|integer|max:47',
             'city_id' => 'nullable|integer|max:1892',
         ]);
+
+        $request['birthday'] = \Carbon\Carbon::paerse($request['birthday'])->format('Y年m月d日');
 
         $player = TPlayer::where('team_id', $team_id)->findOrFail($player_id);
 

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,34 +1,42 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
-import { Head, Link } from '@inertiajs/vue3';
+import { Head, Link, usePage } from '@inertiajs/vue3';
+
+const { props } = usePage();
+const auth = props.auth;
 </script>
 
 <template>
-    <Head title="Dashboard" />
+    <Head title="トップページ" />
 
     <AuthenticatedLayout>
         <template #header>
-            <h2
-                class="text-xl font-semibold leading-tight text-gray-800"
-            >
-                Dashboard
-            </h2>
+            <h1 class="text-3xl font-bold text-center mb-6">
+                <p>ようこそ、{{ auth.user.name }} さん！</p>
+            </h1>
         </template>
 
         <div class="py-12">
-            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
-                <div
-                    class="overflow-hidden bg-white shadow-sm sm:rounded-lg"
-                >
-                    <div class="p-6 text-gray-900">
-                        You're logged in!
-                        <h1>プロ野球選手名鑑</h1>
-                        <Link :href="route('teams.index')">球団一覧</Link><br />
-                        <Link :href="route('favorites.index')">お気に入り選手一覧</Link><br />
+            <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+                <div class="bg-white shadow rounded-lg p-6">
+                
+                    <div v-if="props.flash?.status" class="mb-6 p-4 text-green-800 bg-green-100 border border-green-300 rounded">
+                        {{ props.flash.status }}
                     </div>
+
+                    <h2 class="text-2xl font-semibold mb-4 text-center">プロ野球選手名鑑</h2>
+                    <nav class="space-y-4 text-center">
+                        <Link :href="route('teams.index')"
+                            class="block text-blue-600 hover:underline text-lg">
+                            球団一覧
+                        </Link>
+                        <Link :href="route('favorites.index')"
+                            class="block text-blue-600 hover:underline text-lg">
+                            お気に入り選手一覧
+                        </Link>
+                    </nav>
                 </div>
             </div>
-
         </div>
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Players/Create.vue
+++ b/resources/js/Pages/Players/Create.vue
@@ -26,78 +26,86 @@ const { errors } = form;
 </script>
 
 <template>
+    <Head title="選手登録" />
+
     <AuthenticatedLayout>
         <template #header>
-            <h1>選手登録画面</h1>
+            <h1 class="text-2xl font-bold text-center mb-6">選手登録画面</h1>
         </template>
             
         
-        <div v-if="Object.keys(errors).length" style="color: red;">
+        <div v-if="Object.keys(errors).length" class="mb-4 text-red-600">
             <ul>
                 <li v-for="(message, key) in errors" :key="key">{{ message }}</li>
             </ul>
         </div>
         
-        <label> 球団: {{ team.name }} </label>
-        <form @submit.prevent="form.post(route('players.store', { team_id: props.team.id }))">
-            <label>
-                背番号:
-                <input type="text" v-model="form.uniform_no" />
-            </label><br />
+        <h2 class="mb-6 text-lg font-semibold text-center py-8\">球団: {{ team.name }}</h2>
 
-            <label>
-                名前:
-                <input type="text" v-model="form.name" />
-            </label><br />
+        <form @submit.prevent="form.post(route('players.store', { team_id: props.team.id }))" class="max-w-md mx-auto space-y-6 bg-white p-6 rounded shadow">
+            <div class="flex flex-col">
+                <label for="uniform_no" class="mb-1 font-medium">背番号:</label>
+                <input id="uniform_no" type="text" v-model="form.uniform_no" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
+            </div>
 
-            <label>
-                ポジション:
-                <select v-model="form.position_id">
-                    <option value="" disabled>選択してください</option>
+            <div class="flex flex-col">
+                <label for="name" class="mb-1 font-medium">名前:</label>
+                <input id="name" type="text" v-model="form.name" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
+            </div>
+
+            <div class="flex flex-col">
+                <label for="position_id" class="mb-1 font-medium">ポジション:</label>
+                <select id="position_id" v-model="form.position_id" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    <option value="" disabled selected>選択してください</option>
                     <option v-for="position in props.positions" :key="position.id" :value="position.id">
                         {{ position.name }}
                     </option>
                 </select>
-            </label><br />
+            </div>
 
-            <label>
-                高校:
-                <input type="text" v-model="form.highschool" />
-            </label><br />
 
-            <label>
-                大学:
-                <input type="text" v-model="form.university" />
-            </label><br />
+            <div class="flex flex-col">
+                <label for="highschool" class="mb-1 font-medium">高校:</label>
+                <input id="highschool" type="text" v-model="form.highschool" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
+            </div>
 
-            <label>
-                誕生日:
-                <input type="text" v-model="form.birthday" />
-            </label><br />
+            <div class="flex flex-col">
+                <label for="university" class="mb-1 font-medium">大学:</label>
+                <input id="university" type="text" v-model="form.university" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
+            </div>
 
-            <label>
-                出身地(都道府県):
-                <select v-model="form.prefecture_id">
-                    <option value="" disabled>選択してください</option>
+            <div class="flex flex-col">
+                <label for="birthday" class="mb-1 font-medium">誕生日:</label>
+                <input id="birthday" type="date" v-model="form.birthday" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
+            </div>
+
+            <div class="flex flex-col">
+                <label for="prefecture_id" class="mb-1 font-medium">出身地(都道府県):</label>
+                <select id="prefecture_id" v-model="form.prefecture_id" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    <option value="" disabled selected>選択してください</option>
                     <option v-for="prefecture in props.prefectures" :key="prefecture.id" :value="prefecture.id">
                         {{ prefecture.name }}
                     </option>
                 </select>
-            </label><br />
+            </div>
 
-            <label>
-                出身地(市区町村):
-                <select v-model="form.city_id">
-                    <option value="" disabled>選択してください</option>
+            <div class="flex flex-col">
+                <label for="city_id" class="mb-1 font-medium">出身地(市区町村):</label>
+                <select id="city_id" v-model="form.city_id" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    <option value="" disabled selected>選択してください</option>
                     <option v-for="city in props.citys" :key="city.id" :value="city.id">
                         {{ city.name }}
                     </option>
                 </select>
-            </label><br />
+            </div>
 
-            <button type="submit" :disabled="form.processing">登録</button>
+            <button type="submit" :disabled="form.processing" class="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition-colors">
+                登録
+            </button>
         </form>
-        
-        <Link :href="route('teams.show', { team_id: team.id })">戻る</Link>
+
+        <div class="mt-6 text-center">
+            <Link :href="route('teams.show', { team_id: team.id })" class="text-blue-600 hover:underline">戻る</Link>
+        </div>
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Players/Deleted.vue
+++ b/resources/js/Pages/Players/Deleted.vue
@@ -1,6 +1,6 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
-import { Head, Link, useForm, router } from '@inertiajs/vue3';
+import { Head, Link, useForm } from '@inertiajs/vue3';
 
 const props = defineProps({
   players: Array,
@@ -20,29 +20,43 @@ const restore = (player) => {
 </script>
 
 <template>
+    <Head title="削除された選手一覧" />
+
     <AuthenticatedLayout>
         <template #header>
-            <h1>削除された選手一覧</h1>
+             <h1 class="text-2xl font-bold text-center mb-6">削除された選手一覧</h1>
         </template>
 
-        <div>
-            <table border="1" cellpadding="5">
+        <div class="max-w-4xl mx-auto px-4">
+            <div v-if="props.players.length === 0" class="mb-6 text-gray-600 text-center">
+                削除された選手はいません。
+            </div>
+
+            <table class="w-full table-auto border border-gray-300 shadow-sm mb-6">
                 <thead>
                     <tr>
-                        <th>名前</th>
-                        <th>操作</th>
+                        <th class="px-4 py-2 border-b text-center">名前</th>
+                        <th class="px-4 py-2 border-b text-center">操作</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="player in props.players" :key="player.id">
-                        <td>{{ player.name }}</td>
-                        <td>
-                            <button @click="restore(player)" :disabled="form.processing">復元</button><br />
+                    <tr v-for="player in props.players" :key="player.id" class="hover:bg-gray-50">
+                        <td class="px-4 py-2 border-b text-center">{{ player.name }}</td>
+                        <td class="px-4 py-2 border-b text-center">
+                            <button @click="restore(player)" :disabled="form.processing"
+                                class="bg-blue-600 text-white px-4 py-1 rounded hover:bg-blue-700 disabled:opacity-50">
+                                復元
+                            </button>
                         </td>
                     </tr>
                 </tbody>
             </table>
-            <Link :href="route('players.index', { team_id: props.team_id })">戻る</Link><br />
+            <div class="flex justify-center mt-4">
+                <Link :href="route('players.index', { team_id: props.team_id })"
+                    class="text-blue-600 underline hover:text-blue-800">
+                    戻る
+                </Link>
+            </div>
         </div>
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Players/Edit.vue
+++ b/resources/js/Pages/Players/Edit.vue
@@ -1,6 +1,6 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
-import { Link, useForm, router } from '@inertiajs/vue3';
+import { Head, Link, useForm } from '@inertiajs/vue3';
 
 const props = defineProps({
     player: Object,
@@ -11,7 +11,6 @@ const props = defineProps({
     errors: Object,
 });
 
-const player = props.player;
 
 const form = useForm({
     uniform_no: props.player.uniform_no || '',
@@ -34,81 +33,109 @@ const submit = () => {
         }));
     }
 };
-
 </script>
 
 <template>
+    <Head title="選手情報編集" />
+
     <AuthenticatedLayout>
         <template #header>
-            <h1>選手情報編集画面</h1>
+            <h1 class="text-2xl font-bold text-center mb-6">選手情報編集画面</h1>
         </template>
 
-        <div v-if="Object.keys(errors).length" style="color: red;">
-            <ul>
-                <li v-for="(message, key) in errors" :key="key">{{ message }}</li>
-            </ul>
+        <div class="max-w-md mx-auto px-4 bg-white p-6 rounded shadow">
+            <div v-if="Object.keys(errors).length" class="mb-4 text-red-600">
+                <ul>
+                    <li v-for="(message, key) in errors" :key="key">{{ message }}</li>
+                </ul>
+            </div>
+        
+            <h2 class="text-lg font-semibold mb-4 text-center">球団: {{ props.team.name }}</h2>
+
+            <form @submit.prevent="submit" class="space-y-6">
+                <div class="flex flex-col">
+                    <label class="mb-1 font-medium">背番号:</label>
+                    <input type="text" v-model="form.uniform_no"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    />
+                </div>
+
+                <div class="flex flex-col">
+                    <label class="mb-1 font-medium">名前:</label>
+                    <input type="text" v-model="form.name"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    />
+                </div>
+
+                <div class="flex flex-col" >
+                    <label class="mb-1 font-medium">ポジション:</label>
+                    <select v-model="form.position_id"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    >
+                        <option value="" disabled selected>選択してください</option>
+                        <option v-for="position in props.positions" :key="position.id" :value="position.id">
+                            {{ position.name }}
+                        </option>
+                    </select>
+                </div>
+
+                <div class="flex flex-col">
+                    <label class="mb-1 font-medium">高校:</label>
+                    <input type="text" v-model="form.highschool"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    />
+                </div>
+        
+                <div class="flex flex-col">
+                    <label class="mb-1 font-medium">大学:</label>
+                    <input type="text" v-model="form.university"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    />
+                </div>
+
+                <div class="flex flex-col">
+                    <label for="birthday" class="mb-1 font-medium">誕生日:</label>
+                    <input type="date" v-model="form.birthday"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" 
+                    />
+                </div>
+            
+                <div class="flex flex-col">
+                    <label class="mb-1 font-medium">出身地(都道府県):</label>
+                    <select v-model="form.prefecture_id"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    >
+                        <option value="" disabled selected>選択してください</option>
+                        <option v-for="prefecture in props.prefectures" :key="prefecture.id" :value="prefecture.id">
+                            {{ prefecture.name }}
+                        </option>
+                    </select>
+                </div>
+         
+                <div class="flex flex-col">
+                    <label class="mb-1 font-medium">出身地(市区町村):</label>
+                    <select v-model="form.city_id"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    >
+                        <option value="" disabled selected>選択してください</option>
+                        <option v-for="city in props.citys" :key="city.id" :value="city.id">
+                            {{ city.name }}
+                        </option>
+                    </select>
+                </div>
+
+                 <div class="mt-6 flex flex-col gap-4 items-center">
+                    <button type="submit" :disabled="form.processing"
+                        class="w-full bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 disabled:opacity-50">
+                        更新
+                    </button>
+
+                    <Link :href="route('players.show', { team_id: props.team.id, player_id: props.player.id })"
+                        class="text-blue-600 hover:underline text-blue-800">
+                        戻る
+                    </Link>
+                </div>    
+            </form>
         </div>
-        
-        <label> 球団: {{ team.name }} </label>
-        <form @submit.prevent="submit">
-            <label>
-                背番号:
-                <input type="text" v-model="form.uniform_no" />
-            </label><br />
-
-            <label>
-                名前:
-                <input type="text" v-model="form.name" />
-            </label><br />
-
-            <label>
-                ポジション:
-                <select v-model="form.position_id">
-                    <option value="" disabled>選択してください</option>
-                    <option v-for="position in props.positions" :key="position.id" :value="position.id">
-                        {{ position.name }}
-                    </option>
-                </select>
-            </label><br />
-
-            <label>
-                高校:
-                <input type="text" v-model="form.highschool" />
-            </label><br />
-
-            <label>
-                大学:
-                <input type="text" v-model="form.university" />
-            </label><br />
-            
-            <label>
-                誕生日:
-                <input type="text" v-model="form.birthday" />
-            </label><br />
-            
-            <label>
-                出身地(都道府県):
-                <select v-model="form.prefecture_id">
-                    <option value="" disabled>選択してください</option>
-                    <option v-for="prefecture in props.prefectures" :key="prefecture.id" :value="prefecture.id">
-                        {{ prefecture.name }}
-                    </option>
-                </select>
-            </label><br />
-
-            <label>
-                出身地(市区町村):
-                <select v-model="form.city_id">
-                    <option value="" disabled>選択してください</option>
-                    <option v-for="city in props.citys" :key="city.id" :value="city.id">
-                        {{ city.name }}
-                    </option>
-                </select>
-            </label><br />
-
-            <button type="submit" :disabled="form.processing">更新</button>
-        </form>
-        
-        <Link :href="route('players.show', { team_id: props.team.id, player_id: player.id })">戻る</Link>
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Players/Favorites.vue
+++ b/resources/js/Pages/Players/Favorites.vue
@@ -14,22 +14,29 @@ const props = defineProps({
         <template #header>
             <h1 class="text-xl font-bold">お気に入り選手一覧</h1>
         </template>
-        <div>
-            <table border="1" cellpadding="5">
+        <div class="max-w-3xl mx-auto px-4">
+            <table v-if="players.length" class="table-auto border-collapse border border-gray-300 w-full">
                 <thead>
                     <tr>
-                        <th>名前</th>
-                        <th>チーム</th>
+                        <th class="border border-gray-300 px-4 py-2 text-center">名前</th>
+                        <th class="border border-gray-300 px-4 py-2 text-center">チーム</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="player in props.players" :key="player.id">
-                        <td>{{ player.name}}</td>
-                        <td>{{ player.team.name }}</td>
+                    <tr v-for="player in players" :key="player.id" class="hover:bg-gray-100">
+                        <td class="border border-gray-300 px-4 py-2 text-center">{{ player.name}}</td>
+                        <td class="border border-gray-300 px-4 py-2 text-center">{{ player.team.name }}</td>
                     </tr>
                 </tbody>
             </table>
-            <Link :href="route('dashboard')">トップページへ戻る</Link><br />
+
+            <p v-else class="text-center text-gray-500 mt-6">お気に入り選手が登録されていません。</p>
+            
+            <div class="text-center mt-6">
+                <Link :href="route('dashboard')" class="text-blue-600 hover:underline">
+                    トップページへ戻る
+                </Link>
+            </div>
         </div>
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Players/Index.vue
+++ b/resources/js/Pages/Players/Index.vue
@@ -9,41 +9,50 @@ const props = defineProps({
 </script>
 
 <template>
+    <Head title="選手一覧" />
+
     <AuthenticatedLayout>
         <template #header>
-            <h1>選手一覧</h1>
+            <h1 class="text-2xl font-bold text-center mb-6">選手一覧</h1>
         </template>
 
-        <div>
-            <table border="1" cellpadding="5">
-                <thead>
-                    <tr>
-                        <th>背番号</th>
-                        <th>名前</th>
-                        <th>ポジション</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr v-for="player in props.players" :key="player.id">
-                        <td>
-                            <Link :href="route('players.show', {team_id: props.team.id, player_id: player.id})">
-                                {{ player.uniform_no }}
-                            </Link>
-                        </td>
-                        <td>
-                            <Link :href="route('players.show', {team_id: props.team.id, player_id: player.id})">    
-                                {{ player.name }}
-                            </Link>
-                        </td>
-                        
-                        <td>{{ player.position?.name || '' }}</td>
-                    </tr>
-                </tbody>
-            </table>
-            <Link :href="route('players.deleted', { team_id: props.team.id})">削除選手ページ遷移</Link><br /> 
-            <Link :href="route('teams.show', { team_id: props.team.id})">戻る</Link><br /> 
-            <Link :href="route('favorites.index')">お気に入り選手一覧</Link><br />
-            <Link :href="route('dashboard')">トップページ</Link>
+        <div class="max-w-3xl mx-auto space-y-4">
+            <div v-if="props.players.length" class="space-y-4">
+                <div v-for="player in props.players" :key="player.id"
+                    class="p-4 border rounded shadow-sm hover:shadow-md transition"> 
+                    <Link :href="route('players.show', {team_id: props.team.id, player_id: player.id})"
+                        class="block text-lg font-semibold text-blue-700 hover:underline">
+                        {{ player.uniform_no }}番 - {{ player.name }}
+                    </Link>
+                    <p class="text-gray-600">ポジション:{{ player.position.name }}</p>
+                </div>
+            </div>
+
+            <div v-else class="text-center text-gray-500">
+                選手が登録されていません。
+            </div>
+
+            <div class="mt-6 space-y-3">
+                <Link :href="route('players.deleted', { team_id: props.team.id})"
+                    class="block text-center text-red-600 hover:underline">
+                    削除された選手を見る
+                </Link>
+
+                <Link :href="route('teams.show', { team_id: props.team.id})"
+                    class="block text-center text-blue-600 hover:underline">
+                    チーム詳細に戻る
+                </Link>
+
+                <Link :href="route('favorites.index')"
+                    class="block text-center text-yellow-600 hover:underline">
+                    お気に入り選手一覧
+                </Link>
+                
+                <Link :href="route('dashboard')"
+                    class="block text-center text-blue-600 hover:underline">
+                    トップページへ
+                </Link>
+            </div>
         </div>
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Players/Show.vue
+++ b/resources/js/Pages/Players/Show.vue
@@ -30,7 +30,6 @@ const toggleFavorite = async () => {
 
     const data = await response.json();
     props.player.is_favorite = data.is_favorite;
-
   } catch (error) {
     console.error(error);
   }
@@ -39,47 +38,54 @@ const toggleFavorite = async () => {
 </script>
 
 <template>
+    <Head title="選手詳細" />
+    
     <AuthenticatedLayout>
         <template #header>
-            <h1>選手詳細</h1>
+            <h1 class="text-2xl font-bold text-center mb-6">選手詳細</h1>
         </template>
 
-        <div>
-            <table border="1" cellpadding="5">
-                <thead>
-                    <tr>
-                        <th>背番号</th>
-                        <th>名前</th>
-                        <th>ポジション</th>
-                        <th>球団</th>
-                        <th>高校</th>
-                        <th>大学</th>
-                        <th>誕生日</th>
-                        <th>出身地(都道府県)</th>
-                        <th>出身地(市区町村)</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>{{ props.player.uniform_no }}</td>
-                        <td>{{ props.player.name }}</td>
-                        <td>{{ props.player.position?.name || '' }}</td>
-                        <td>{{ props.player.team?.name || '' }}</td>
-                        <td>{{ props.player.highschool }}</td>
-                        <td>{{ props.player.university }}</td>
-                        <td>{{ props.player.birthday }}</td>
-                        <td>{{ props.player.prefecture?.name || '' }}</td>
-                        <td>{{ props.player.city?.name || '' }}</td>
-                    </tr>
-                </tbody>
-            </table>
-            <button @click="toggleFavorite" :disabled="form.processing">
-                {{ props.player.is_favorite ? '★ お気に入り' : '☆ お気に入りに追加' }}
-            </button><br />
-            <Link :href="route('players.edit', {'team_id': props.team.id, 'player_id': props.player.id})">編集</Link><br />
-            <button @click="destroy" :disabled="form.processing">削除</button><br />
-            <Link :href="route('players.index', {'team_id': props.team.id})">戻る</Link><br />
-            <Link :href="route('dashboard')">トップページ</Link>
+        <div class="max-w-md mx-auto bg-white p-6 rounded shadow space-y-4">
+            <div class="text-center">
+                <button @click="toggleFavorite" :disabled="form.processing"
+                    class="text-2xl focus:outline-none hover:scale-110 transition-transform">
+                        {{ props.player.is_favorite ? '★お気に入り': '☆お気に入り追加' }}
+                </button>
+            </div>    
+            
+            <div class="space-y-2">
+                <p><span class="font-semibold">背番号:</span> {{ props.player.uniform_no }} </p>
+                <p><span class="font-semibold">名前:</span> {{ props.player.name }} </p>
+                <p><span class="font-semibold">ポジション:</span> {{ props.player.position.name }} </p>
+                <p><span class="font-semibold">球団:</span> {{ props.player.team.name }} </p>
+                <p><span class="font-semibold">高校:</span> {{ props.player.highschool || '-' }} </p>
+                <p><span class="font-semibold">大学:</span> {{ props.player.university  || '-' }} </p>
+                <p><span class="font-semibold">誕生日:</span> {{ props.player.birthday   || '-' }} </p>
+                <p><span class="font-semibold">出身地(都道府県):</span> {{ props.player.prefecture?.name || '-' }} </p>
+                <p><span class="font-semibold">出身地(市区町村):</span> {{ props.player.city?.name || '-' }} </p>
+            </div>
+            
+            <div class="mt-6 space-y-3">
+                <Link :href="route('players.edit', {'team_id': props.team.id, 'player_id': props.player.id})"
+                    class="block w-full text-center bg-yellow-500 hover:bg-yellow-600 text-white py-2 rounded transition">
+                    編集
+                </Link>
+
+                <button @click="destroy" :disabled="form.processing"
+                    class="w-full bg-red-600 hover:bg-red-700 text-white py-2 rounded transition disabbled:opacity-50">
+                    削除
+                </button>
+
+                <Link :href="route('players.index', {'team_id': props.team.id})"
+                    class="block w-full text-center text-blue-600 hover:underline">
+                    戻る
+                </Link>
+
+                <Link :href="route('dashboard')"
+                    class="block w-full text-center text-blue-600 hover:underline">
+                    トップページ
+                </Link>
+            </div>
         </div>
     </AuthenticatedLayout>
 </template>


### PR DESCRIPTION
## 概要
選手関連画面（一覧 / 詳細 / 編集 / 作成 / 削除された選手 / お気に入り選手）およびトップページのUIを統一し、以下の改善を行いました。

## 変更内容
- 全ページの見出し・フォントサイズ・マージン・パディングの統一
- ボタンやリンクの色・スタイルを一貫したトーンで統一
- テーブルやカードのレイアウト改善（中央寄せ、余白の調整など）
- テキストの位置や強調（`font-bold`, `text-center` など）を調整
- 表示がない場合の空メッセージ（例：お気に入りがない時）を統一した表現に変更

## 対象画面
- トップページ
- 選手一覧
- 選手詳細
- 選手編集
- 選手作成
- 削除された選手一覧
- お気に入り選手一覧

