### PR TITLE
UIを統一し選手関連画面のデザインを改善（チーム一覧、チーム詳細）

### DIFF
--- a/resources/js/Pages/Teams/Index.vue
+++ b/resources/js/Pages/Teams/Index.vue
@@ -2,35 +2,42 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head, Link } from '@inertiajs/vue3';
 
-defineProps ({ teams:Array, });
+defineProps ({ teams: Array, });
 </script>
 
 <template>
+    <Head title="球団一覧" />
+
     <AuthenticatedLayout>
         <template #header>
-            <h1>球団一覧</h1>
+            <h1 class="text-2xl font-bold text-center mb-6">球団一覧</h1>
         </template>
             
-        <div>
-            <table border="1" cellpadding="5">
+        <div class="max-w-3xl mx-auto">
+            <table v-if="teams.length" class="table-auto border-collapse border border-gray-300 w-full">
                 <thead>
-                    <tr>
-                        <th>id</th>
-                        <th>球団名</th>
+                    <tr class="bg-gray-100">
+                        <th class="border border-gray-300 px-4 py-2 text-center">球団名</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="team in teams" :key="team.id">
-                        <td>{{ team.id }}</td>
-                        <td>
-                            <Link :href="route('teams.show', {team_id: team.id})">
+                    <tr v-for="team in teams" :key="team.id" class="hover:bg-gray-100">
+                        <td class="border border-gray-300 px-4 py-2 text-center">
+                            <Link :href="route('teams.show', {team_id: team.id})"
+                                class="text-blue-600 hover:underline">
                                 {{ team.name }}
                             </Link>
                         </td>
                     </tr>
                 </tbody>
             </table>
-            <Link :href="route('dashboard')">戻る</Link><br /> 
+
+            <p v-else class="text-center text-gray-500 mt-6">球団が登録されていません。</p>
+            <div class="text-center mt-6">
+                <Link :href="route('dashboard')" class="inline-block text-blue-600 hover:underline">
+                    トップページへ戻る
+                </Link>
+            </div>
         </div> 
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Teams/Show.vue
+++ b/resources/js/Pages/Teams/Show.vue
@@ -3,18 +3,32 @@ import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head, Link } from '@inertiajs/vue3';
 
 defineProps({ 
-    team:Object
+    team: Object
 });
 </script>
 
 <template>
+    <Head :title="`${team.name} | チーム詳細`" />
     <AuthenticatedLayout>
         <template #header>
-            <h1>{{ team.name }}ページ</h1>
+            <h1 class="text-2xl font-bold text-center mb-6">{{ team.name }} のページ</h1>
         </template>
         
-        <Link :href="route('players.index', {team_id: team.id})">所属選手一覧</Link><br />
-        <Link :href="route('players.create', {team_id: team.id})">選手追加</Link><br />
-        <Link :href="route('teams.index')">戻る</Link><br /> 
+        <div class="max-w-md mx-auto space-y-4 text-center">
+            <Link :href="route('players.index', {team_id: team.id})"
+                class="inline-block w-full bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded transition">
+                所属選手一覧
+            </Link>
+            
+            <Link :href="route('players.create', {team_id: team.id})"
+                class="inline-block w-full bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded transition">
+                選手追加
+            </Link>
+            
+            <Link :href="route('teams.index')"
+                class="inline-block w-full text-blue-600 hover:underline mt-4">
+                戻る
+            </Link>
+        </div>
     </AuthenticatedLayout>
 </template>


### PR DESCRIPTION
### **チーム一覧画面**
- タイトルの中央配置、フォントスタイルの統一
- 表形式のスタイル統一（余白、ボーダー、ホバー時の視認性向上）
- 戻るリンクを中央寄せに変更し、全体バランスを調整

### **チーム詳細画面**
- ページタイトルのスタイル統一（フォントサイズ、余白）
- アクションリンクをボタン化（選手一覧、選手追加）
- 全体を中央寄せにし、UI整合性を強化