### PR TITLE
市区町村を動的に制御する処理作成

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,17 +4,16 @@
     "es2021": true,
     "node": true
   },
-  "parser": "@typescript-eslint/parser",
+  "extends": [
+    "eslint:recommended",
+    "plugin:vue/vue3-recommended",
+    "plugin:prettier/recommended"
+  ],
   "parserOptions": {
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "prettier"],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended"
-  ],
+  "plugins": ["vue", "prettier"],
   "rules": {
     "prettier/prettier": "error"
   }

--- a/app/Http/Controllers/MCityController.php
+++ b/app/Http/Controllers/MCityController.php
@@ -3,8 +3,13 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\MCity;
 
 class MCityController extends Controller
 {
-    //
+    public function getByPrefecture($prefecture)
+    {
+        $citys = MCity::where('prefectures_id', $prefecture)->get();
+        return response()->json($citys);
+    }
 }

--- a/app/Models/MCity.php
+++ b/app/Models/MCity.php
@@ -11,7 +11,7 @@ class MCity extends Model
 
     public $timestamps = false;
 
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'prefectures_id'];
 
     public function players(){
         return $this->hasMany(TPlayer::class, 'city_id');

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,6 +19,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Vite::prefetch(concurrency: 3);
+        //
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        parent::boot();
+        
+        $this->routes(function () {
+            Route::middleware('api')
+                ->prefix('api')
+                ->group(base_path('routes/api.php'));
+
+            Route::middleware('web')
+                ->group(base_path('routes/web.php'));
+        });
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -122,5 +122,55 @@ return [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Autoloaded Service Providers
+    |--------------------------------------------------------------------------
+    |
+    | The service providers listed here will be automatically loaded on the
+    | request to your application. Feel free to add your own services to
+    | this array to grant expanded functionality to your applications.
+    |
+    */
+
+    'providers' => [
+
+        /*
+         * Laravel Framework Service Providers...
+         */
+        Illuminate\Auth\AuthServiceProvider::class,
+        Illuminate\Broadcasting\BroadcastServiceProvider::class,
+        Illuminate\Bus\BusServiceProvider::class,
+        Illuminate\Cache\CacheServiceProvider::class,
+        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
+        Illuminate\Cookie\CookieServiceProvider::class,
+        Illuminate\Database\DatabaseServiceProvider::class,
+        Illuminate\Encryption\EncryptionServiceProvider::class,
+        Illuminate\Filesystem\FilesystemServiceProvider::class,
+        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
+        Illuminate\Hashing\HashServiceProvider::class,
+        Illuminate\Mail\MailServiceProvider::class,
+        Illuminate\Notifications\NotificationServiceProvider::class,
+        Illuminate\Pagination\PaginationServiceProvider::class,
+        Illuminate\Pipeline\PipelineServiceProvider::class,
+        Illuminate\Queue\QueueServiceProvider::class,
+        Illuminate\Redis\RedisServiceProvider::class,
+        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
+        Illuminate\Session\SessionServiceProvider::class,
+        Illuminate\Translation\TranslationServiceProvider::class,
+        Illuminate\Validation\ValidationServiceProvider::class,
+        Illuminate\View\ViewServiceProvider::class,
+
+        /*
+         * Application Service Providers...
+         */
+        App\Providers\AppServiceProvider::class,
+        // App\Providers\AuthServiceProvider::class,
+        // App\Providers\BroadcastServiceProvider::class,
+        // App\Providers\EventServiceProvider::class,
+        App\Providers\RouteServiceProvider::class,
+    ],
+
 
 ];

--- a/database/migrations/2025_06_09_033452_rename_prefetures_id_to_prefectures_id_in_m_citys_table.php
+++ b/database/migrations/2025_06_09_033452_rename_prefetures_id_to_prefectures_id_in_m_citys_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('m_citys', function (Blueprint $table) {
+            //
+            $table->renameColumn('prefetures_id', 'prefectures_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('m_city', function (Blueprint $table) {
+            //
+            $table->renameColumn('prefectures_id', 'prefetures_id');
+        });
+    }
+};

--- a/resources/js/Pages/Players/Edit.vue
+++ b/resources/js/Pages/Players/Edit.vue
@@ -1,6 +1,8 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ref, watch } from 'vue';
+import axios from 'axios';
 
 const props = defineProps({
     player: Object,
@@ -21,6 +23,24 @@ const form = useForm({
     birthday: props.player.birthday || '',
     prefecture_id: props.player.prefecture_id || '',
     city_id: props.player.city_id || '',
+});
+
+const citys = ref(props.citys);
+
+watch(() => form.prefecture_id, async (newPrefId) => {
+    if(newPrefId) {
+        try{
+            const response = await axios.get(`/api/prefectures/${newPrefId}/citys`);
+            console.log('API response:', response.data); 
+            citys.value = response.data;
+            form.city_id = '';
+        } catch (error) {
+            console.log('市区町村の取得に失敗しました。', error);
+        }
+    } else {
+        citys.value = [];
+        form.city_id = '';
+    }
 });
 
 const { errors } = form;
@@ -72,7 +92,7 @@ const submit = () => {
                     <select v-model="form.position_id"
                         class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
                     >
-                        <option value="" disabled selected>選択してください</option>
+                        <option value="" disabled>選択してください</option>
                         <option v-for="position in props.positions" :key="position.id" :value="position.id">
                             {{ position.name }}
                         </option>
@@ -105,7 +125,7 @@ const submit = () => {
                     <select v-model="form.prefecture_id"
                         class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
                     >
-                        <option value="" disabled selected>選択してください</option>
+                        <option value="" disabled>選択してください</option>
                         <option v-for="prefecture in props.prefectures" :key="prefecture.id" :value="prefecture.id">
                             {{ prefecture.name }}
                         </option>
@@ -117,8 +137,8 @@ const submit = () => {
                     <select v-model="form.city_id"
                         class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
                     >
-                        <option value="" disabled selected>選択してください</option>
-                        <option v-for="city in props.citys" :key="city.id" :value="city.id">
+                        <option value="" disabled>選択してください</option>
+                        <option v-for="city in citys" :key="city.id" :value="city.id">
                             {{ city.name }}
                         </option>
                     </select>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\MCityController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('prefectures/{prefecture}/citys', [MCityController::class, 'getByPrefecture']);


### PR DESCRIPTION
### 概要

- 選手情報編集画面において、都道府県選択に連動して市区町村の選択肢を動的に切り替える機能を実装。
- Vueの`watch`を用いて、`prefecture_id`が変更された際にAPIへリクエストを送り、該当する市区町村データを取得して表示を更新。
- APIはLaravelのコントローラで実装し、指定都道府県に紐づく市区町村情報をJSONで返却。
- これにより、市区町村のプルダウンは常に最新の都道府県に基づいた情報を表示し、ユーザビリティが向上。

### 詳細

- `edit.vue`の`watch`で`prefecture_id`の変更を監視し、変更時に`axios.get`で`/api/prefectures/{prefecture_id}/citys`へリクエスト
- APIレスポンスの市区町村データを`citys`というrefに格納し、プルダウンの選択肢を動的に更新
- フォームの`city_id`は都道府県変更時にクリアし、誤った市区町村選択を防止
- バックエンドの`MCityController`で都道府県IDに紐づく市区町村をDBから取得し返却

### 確認事項

- 都道府県選択時に市区町村が正しく絞り込まれて表示されること
- APIの動作が正常で、適切なデータが返ってくること
- バリデーションエラー時にエラーメッセージが表示されること
- その他既存機能に影響がないこと

---

