### PR TITLE
選手作成画面も市区町村を動的に制御できるよう修正

### DIFF
--- a/resources/js/Pages/Players/Create.vue
+++ b/resources/js/Pages/Players/Create.vue
@@ -1,6 +1,8 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ref, watch } from 'vue';
+import axios from 'axios';
 
 const props = defineProps ({ 
     teams:Array,
@@ -19,6 +21,24 @@ const form = useForm({
     birthday: '2000-01-01',
     prefecture_id: '',
     city_id: '',
+});
+
+const citys = ref(props.citys);
+
+watch(() => form.prefecture_id, async (newPrefId) => {
+    if(newPrefId) {
+        try{
+            const response = await axios.get(`/api/prefectures/${newPrefId}/citys`);
+            console.log('API response:', response.data); 
+            citys.value = response.data;
+            form.city_id = '';
+        } catch (error) {
+            console.log('市区町村の取得に失敗しました。', error);
+        }
+    } else {
+        citys.value = [];
+        form.city_id = ''
+    }
 });
 
 const { errors } = form;
@@ -56,7 +76,7 @@ const { errors } = form;
             <div class="flex flex-col">
                 <label for="position_id" class="mb-1 font-medium">ポジション:</label>
                 <select id="position_id" v-model="form.position_id" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
-                    <option value="" disabled selected>選択してください</option>
+                    <option value="" disabled>選択してください</option>
                     <option v-for="position in props.positions" :key="position.id" :value="position.id">
                         {{ position.name }}
                     </option>
@@ -82,7 +102,7 @@ const { errors } = form;
             <div class="flex flex-col">
                 <label for="prefecture_id" class="mb-1 font-medium">出身地(都道府県):</label>
                 <select id="prefecture_id" v-model="form.prefecture_id" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
-                    <option value="" disabled selected>選択してください</option>
+                    <option value="" disabled>選択してください</option>
                     <option v-for="prefecture in props.prefectures" :key="prefecture.id" :value="prefecture.id">
                         {{ prefecture.name }}
                     </option>
@@ -92,8 +112,8 @@ const { errors } = form;
             <div class="flex flex-col">
                 <label for="city_id" class="mb-1 font-medium">出身地(市区町村):</label>
                 <select id="city_id" v-model="form.city_id" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400">
-                    <option value="" disabled selected>選択してください</option>
-                    <option v-for="city in props.citys" :key="city.id" :value="city.id">
+                    <option value="" disabled>選択してください</option>
+                    <option v-for="city in citys" :key="city.id" :value="city.id">
                         {{ city.name }}
                     </option>
                 </select>


### PR DESCRIPTION
### 概要

- 選手登録画面において、都道府県選択に連動して市区町村の選択肢を動的に切り替える機能を実装しました。
- Vueの`watch`を用いて、`prefecture_id`が変更された際にAPIへリクエストを送り、該当する市区町村データを取得して表示を更新。
- APIはLaravelのコントローラで実装し、指定都道府県に紐づく市区町村情報をJSONで返却。
- これにより、市区町村のプルダウンは常に最新の都道府県に基づいた情報を表示し、ユーザビリティが向上。

### 詳細

- `edit.vue`の`watch`で`prefecture_id`の変更を監視し、変更時に`axios.get`で`/api/prefectures/{prefecture_id}/citys`へリクエスト
- APIレスポンスの市区町村データを`citys`というrefに格納し、プルダウンの選択肢を動的に更新
- フォームの`city_id`は都道府県変更時にクリアし、誤った市区町村選択を防止
- バックエンドの`MCityController`で都道府県IDに紐づく市区町村をDBから取得し返却

### 確認事項

- 都道府県選択時に市区町村が正しく絞り込まれて表示されること
- APIの動作が正常で、適切なデータが返ってくること
- バリデーションエラー時にエラーメッセージが表示されること
- その他既存機能に影響がないこと

---

