### PR TITLE
Pages公開に向けてhomepageとbase設定を変更

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  
+"homepage": "https://imurar.github.io/npb-directory-Laravel",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,7 +5,7 @@ const repoName = 'npb-directory-Laravel'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: `/${repoName}`,
+  base: `/${repoName}/`,
   build: {
     outDir: 'dist',
   },


### PR DESCRIPTION
- package.jsonにhomepageを設定し、GitHub PagesのURLを指定しました
- vite.config.jsのbaseオプションをリポジトリパスに合わせて修正しました
- これにより、ビルド時に正しいパスでファイルが読み込まれるようになります

フロントエンドをGitHub Pagesで正しく公開するための準備。
