### PR TITLE
会社情報カラムを入力できる用修正

### DIFF
--- a/app/Http/Controllers/TPlayerController.php
+++ b/app/Http/Controllers/TPlayerController.php
@@ -38,6 +38,7 @@ class TPlayerController extends Controller
             'uniform_no' => 'required|string|max:10',
             'highschool' => 'nullable|string|max:255',
             'university' => 'nullable|string|max:255',
+            'company' => 'nullable|string|max:255',
             'birthday' => 'required|date',
             'prefecture_id' => 'nullable|integer|max:47',
             'city_id' => 'nullable|integer|max:1892',

--- a/resources/js/Pages/Players/Create.vue
+++ b/resources/js/Pages/Players/Create.vue
@@ -18,6 +18,7 @@ const form = useForm({
     position_id: '',
     highschool: '',
     university: '',
+    company: '',
     birthday: '2000-01-01',
     prefecture_id: '',
     city_id: '',
@@ -92,6 +93,11 @@ const { errors } = form;
             <div class="flex flex-col">
                 <label for="university" class="mb-1 font-medium">大学:</label>
                 <input id="university" type="text" v-model="form.university" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
+            </div>
+
+            <div class="flex flex-col">
+                <label for="company" class="mb-1 font-medium">会社:</label>
+                <input id="company" type="text" v-model="form.company" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
             </div>
 
             <div class="flex flex-col">

--- a/resources/js/Pages/Players/Edit.vue
+++ b/resources/js/Pages/Players/Edit.vue
@@ -20,6 +20,7 @@ const form = useForm({
     position_id: props.player.position_id || '',
     highschool: props.player.highschool || '',
     university: props.player.university || '',
+    company: props.player.company || '',
     birthday: props.player.birthday || '',
     prefecture_id: props.player.prefecture_id || '',
     city_id: props.player.city_id || '',
@@ -109,6 +110,13 @@ const submit = () => {
                 <div class="flex flex-col">
                     <label class="mb-1 font-medium">大学:</label>
                     <input type="text" v-model="form.university"
+                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    />
+                </div>
+
+                <div class="flex flex-col">
+                    <label class="mb-1 font-medium">会社:</label>
+                    <input type="text" v-model="form.company"
                         class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
                     />
                 </div>

--- a/resources/js/Pages/Players/Show.vue
+++ b/resources/js/Pages/Players/Show.vue
@@ -60,6 +60,7 @@ const toggleFavorite = async () => {
                 <p><span class="font-semibold">球団:</span> {{ props.player.team.name }} </p>
                 <p><span class="font-semibold">高校:</span> {{ props.player.highschool || '-' }} </p>
                 <p><span class="font-semibold">大学:</span> {{ props.player.university  || '-' }} </p>
+                <p><span class="font-semibold">会社:</span> {{ props.player.company  || '-' }} </p>
                 <p><span class="font-semibold">誕生日:</span> {{ props.player.birthday   || '-' }} </p>
                 <p><span class="font-semibold">出身地(都道府県):</span> {{ props.player.prefecture?.name || '-' }} </p>
                 <p><span class="font-semibold">出身地(市区町村):</span> {{ props.player.city?.name || '-' }} </p>


### PR DESCRIPTION


##  機能追加: プレイヤーに会社情報を登録・表示できるように対応

### 概要
プレイヤー情報に「会社（company）」を追加。
登録・編集・詳細表示の各画面で会社情報を入力・確認できるようになった。

---

###  バックエンド（`t_playerController`）
- バリデーションルールに以下を追加：
  ```php
  'company' => 'nullable|string|max:255',
  ```

---

###  フロントエンド

#### `Players/Create.vue`
- `form` に `company: ''` を追加
- 入力欄を追加：
  ```vue
  <div class="flex flex-col">
    <label for="company" class="mb-1 font-medium">会社:</label>
    <input id="company" type="text" v-model="form.company" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
  </div>
  ```

#### `Players/Edit.vue`
- `form` 初期化時に `company: props.player.company || ''` を追加
- 入力欄を追加：
  ```vue
  <div class="flex flex-col">
    <label class="mb-1 font-medium">会社:</label>
    <input type="text" v-model="form.company" class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" />
  </div>
  ```

#### `Players/Show.vue`
- 表示エリアに会社情報を追加：
  ```vue
  <p><span class="font-semibold">会社:</span> {{ props.player.company || '-' }} </p>
  ```

---

###  補足
- `company` は任意入力（nullable）。
- 未入力の場合、詳細画面では `-` が表示される。

---

