### PR TITLE
選手登録・編集（store, update）機能の二重登録防止修正

### DIFF
--- a/app/Http/Controllers/TPlayerController.php
+++ b/app/Http/Controllers/TPlayerController.php
@@ -98,13 +98,22 @@ class TPlayerController extends Controller
         $request->validate([
             'name' => 'required|string|max:255',
             'position_id' => 'required|integer|max:9',
-            'uniform_no' => 'required|string|max:10',
+            'uniform_no' => [
+                'required',
+                'max:10',
+                Rule::unique('t_players')->where(function ($query) use($request, $team_id) {
+                    return $query->where('name', $request->name)
+                                ->where('team_id', $team_id);
+                })->ignore($player_id),
+            ],
             'highschool' => 'nullable|string|max:255',
             'university' => 'nullable|string|max:255',
             'birthday' => 'nullable|date',
             'prefecture_id' => 'nullable|integer|max:47',
             'city_id' => 'nullable|integer|max:1892',
-        ]);
+        ], [
+                'uniform_no.unique' => 'この選手名と背番号の組み合わせはすでに登録されています。',
+            ]);
 
         $request['birthday'] = \Carbon\Carbon::parse($request['birthday'])->format('Y-m-d');
 

--- a/resources/js/Pages/Players/Edit.vue
+++ b/resources/js/Pages/Players/Edit.vue
@@ -13,6 +13,7 @@ const props = defineProps({
     errors: Object,
 });
 
+const citys = ref(props.citys);
 
 const form = useForm({
     uniform_no: props.player.uniform_no || '',
@@ -26,7 +27,6 @@ const form = useForm({
     city_id: props.player.city_id || '',
 });
 
-const citys = ref(props.citys);
 
 watch(() => form.prefecture_id, async (newPrefId) => {
     if(newPrefId) {
@@ -64,106 +64,111 @@ const submit = () => {
             <h1 class="text-2xl font-bold text-center mb-6">選手情報編集画面</h1>
         </template>
 
-        <div class="max-w-md mx-auto px-4 bg-white p-6 rounded shadow">
-            <div v-if="Object.keys(errors).length" class="mb-4 text-red-600">
-                <ul>
-                    <li v-for="(message, key) in errors" :key="key">{{ message }}</li>
-                </ul>
+        <div v-if="Object.keys(form.errors).length" class="mb-4 text-red-600">
+            <ul>
+                <li v-for="(messages, key) in form.errors" :key="key">
+                    <template v-if="Array.isArray(messages)">
+                        <div v-for="msg in messages" :key="msg">{{ msg }}</div>
+                    </template>
+                    <template v-else>
+                        {{ messages }}
+                    </template>
+                </li>
+            </ul>
+        </div>
+        
+        <h2 class="text-lg font-semibold mb-4 text-center">球団: {{ props.team.name }}</h2>
+
+        <form @submit.prevent="submit" class="max-w-md mx-auto space-y-6 bg-white p-6 rounded shadow">
+            <div class="flex flex-col">
+                <label class="mb-1 font-medium">背番号:</label>
+                <input type="text" v-model="form.uniform_no"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+            </div>
+
+            <div class="flex flex-col">
+                <label class="mb-1 font-medium">名前:</label>
+                <input type="text" v-model="form.name"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"                    
+                />
+            </div>
+
+            <div class="flex flex-col" >
+                <label class="mb-1 font-medium">ポジション:</label>
+                <select v-model="form.position_id"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                >
+                    <option value="" disabled>選択してください</option>
+                    <option v-for="position in props.positions" :key="position.id" :value="position.id">
+                        {{ position.name }}
+                    </option>
+                </select>
+            </div>
+
+            <div class="flex flex-col">
+                <label class="mb-1 font-medium">高校:</label>
+                <input type="text" v-model="form.highschool"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
             </div>
         
-            <h2 class="text-lg font-semibold mb-4 text-center">球団: {{ props.team.name }}</h2>
+            <div class="flex flex-col">
+                <label class="mb-1 font-medium">大学:</label>
+                <input type="text" v-model="form.university"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+            </div>
 
-            <form @submit.prevent="submit" class="space-y-6">
-                <div class="flex flex-col">
-                    <label class="mb-1 font-medium">背番号:</label>
-                    <input type="text" v-model="form.uniform_no"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    />
-                </div>
+            <div class="flex flex-col">
+                <label class="mb-1 font-medium">会社:</label>
+                <input type="text" v-model="form.company"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+            </div>
 
-                <div class="flex flex-col">
-                    <label class="mb-1 font-medium">名前:</label>
-                    <input type="text" v-model="form.name"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    />
-                </div>
-
-                <div class="flex flex-col" >
-                    <label class="mb-1 font-medium">ポジション:</label>
-                    <select v-model="form.position_id"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    >
-                        <option value="" disabled>選択してください</option>
-                        <option v-for="position in props.positions" :key="position.id" :value="position.id">
-                            {{ position.name }}
-                        </option>
-                    </select>
-                </div>
-
-                <div class="flex flex-col">
-                    <label class="mb-1 font-medium">高校:</label>
-                    <input type="text" v-model="form.highschool"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    />
-                </div>
-        
-                <div class="flex flex-col">
-                    <label class="mb-1 font-medium">大学:</label>
-                    <input type="text" v-model="form.university"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    />
-                </div>
-
-                <div class="flex flex-col">
-                    <label class="mb-1 font-medium">会社:</label>
-                    <input type="text" v-model="form.company"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    />
-                </div>
-
-                <div class="flex flex-col">
-                    <label for="birthday" class="mb-1 font-medium">誕生日:</label>
-                    <input type="date" v-model="form.birthday"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" 
-                    />
-                </div>
+            <div class="flex flex-col">
+                <label for="birthday" class="mb-1 font-medium">誕生日:</label>
+                <input type="date" v-model="form.birthday"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" 
+                />
+            </div>
             
-                <div class="flex flex-col">
-                    <label class="mb-1 font-medium">出身地(都道府県):</label>
-                    <select v-model="form.prefecture_id"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    >
-                        <option value="" disabled>選択してください</option>
-                        <option v-for="prefecture in props.prefectures" :key="prefecture.id" :value="prefecture.id">
-                            {{ prefecture.name }}
-                        </option>
-                    </select>
-                </div>
+            <div class="flex flex-col">
+                <label class="mb-1 font-medium">出身地(都道府県):</label>
+                <select v-model="form.prefecture_id"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                >
+                    <option value="" disabled>選択してください</option>
+                    <option v-for="prefecture in props.prefectures" :key="prefecture.id" :value="prefecture.id">
+                        {{ prefecture.name }}
+                    </option>
+                </select>
+            </div>
          
-                <div class="flex flex-col">
-                    <label class="mb-1 font-medium">出身地(市区町村):</label>
-                    <select v-model="form.city_id"
-                        class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    >
-                        <option value="" disabled>選択してください</option>
-                        <option v-for="city in citys" :key="city.id" :value="city.id">
-                            {{ city.name }}
-                        </option>
-                    </select>
-                </div>
+            <div class="flex flex-col">
+                <label class="mb-1 font-medium">出身地(市区町村):</label>
+                <select v-model="form.city_id"
+                    class="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                >
+                    <option value="" disabled>選択してください</option>
+                    <option v-for="city in citys" :key="city.id" :value="city.id">
+                        {{ city.name }}
+                    </option>
+                </select>
+            </div>
 
-                 <div class="mt-6 flex flex-col gap-4 items-center">
-                    <button type="submit" :disabled="form.processing"
-                        class="w-full bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 disabled:opacity-50">
-                        更新
-                    </button>
+            <div class="mt-6 flex flex-col gap-4 items-center">
+                <button type="submit" :disabled="form.processing"
+                    class="w-full bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 disabled:opacity-50">
+                    更新
+                </button>
 
-                    <Link :href="route('players.show', { team_id: props.team.id, player_id: props.player.id })"
-                        class="text-blue-600 hover:underline text-blue-800">
-                        選手詳細に戻る
-                    </Link>
-                </div>    
-            </form>
-        </div>
+                <Link :href="route('players.show', { team_id: props.team.id, player_id: props.player.id })"
+                    class="text-blue-600 hover:underline text-blue-800">
+                    選手詳細に戻る
+                </Link>
+            </div>    
+        </form>
     </AuthenticatedLayout>
 </template>


### PR DESCRIPTION
## 概要

選手登録・編集（store, update）機能に関して、下記の修正・改善を行いました。

---

### 1. バックエンド（Controller側）

- **バリデーション強化**
    - `uniform_no` については `team_id` と `name` の組み合わせで複合ユニーク制約を追加し、既存レコードの更新時は自身を除外。
    - ユニーク制約エラー時のメッセージを `"この選手名と背番号の組み合わせはすでに登録されています。"` に。
---

### 2. フロントエンド（Vue側）

- **エラーメッセージの表示改善**
    - `form.errors` の中身を画面上に赤字でリスト表示。
    - エラー項目によっては複数メッセージが配列で返る場合にも対応。
    - 例: 
      ```vue
      <div v-if="Object.keys(form.errors).length" class="mb-4 text-red-600">
        <ul>
          <li v-for="(messages, key) in form.errors" :key="key">
            <template v-if="Array.isArray(messages)">
              <div v-for="msg in messages" :key="msg">{{ msg }}</div>
            </template>
            <template v-else>
              {{ messages }}
            </template>
          </li>
        </ul>
      </div>
      ```
---

### 3. updateアクション（コントローラ）

```php
public function update(Request $request, $team_id, $player_id)
{
    $validated = $request->validate([
        'name' => 'required|string|max:255',
        'position_id' => 'required|integer|max:9',
        'uniform_no' => [
            'required',
            'max:10',
            Rule::unique('t_players')->where(function ($query) use ($request, $team_id) {
                return $query->where('name', $request->name)
                             ->where('team_id', $team_id);
            })->ignore($player_id),
        ],
        'highschool' => 'nullable|string|max:255',
        'university' => 'nullable|string|max:255',
        'company' => 'nullable|string|max:255',
        'birthday' => 'nullable|date',
        'prefecture_id' => 'nullable|integer|max:47',
        'city_id' => 'nullable|integer|max:1892',
    ], [
        'uniform_no.unique' => 'この選手名と背番号の組み合わせはすでに登録されています。',
    ]);
```

---

