### PR TITLE
feat: add-migration

### DIFF
--- a/app/Models/BatterStat.php
+++ b/app/Models/BatterStat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BatterStat extends Model
+{
+    //
+}

--- a/app/Models/PitcherStat.php
+++ b/app/Models/PitcherStat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PitcherStat extends Model
+{
+    //
+}

--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Player extends Model
+{
+    //
+}

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Position extends Model
+{
+    //
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    //
+}

--- a/database/migrations/2025_07_10_000444_create_teams_table.php
+++ b/database/migrations/2025_07_10_000444_create_teams_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/database/migrations/2025_07_10_000444_create_teams_table.php
+++ b/database/migrations/2025_07_10_000444_create_teams_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
     {
         Schema::create('teams', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('abbreviation')->nullable();
+            $table->string('logo_url')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_10_001545_create_positions_table.php
+++ b/database/migrations/2025_07_10_001545_create_positions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('positions', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('positions');
+    }
+};

--- a/database/migrations/2025_07_10_001545_create_positions_table.php
+++ b/database/migrations/2025_07_10_001545_create_positions_table.php
@@ -13,7 +13,8 @@ return new class extends Migration
     {
         Schema::create('positions', function (Blueprint $table) {
             $table->id();
-            $table->timestamps();
+            $table->string('name');
+            $table->string('abbreviation');
         });
     }
 

--- a/database/migrations/2025_07_10_001726_create_players_table.php
+++ b/database/migrations/2025_07_10_001726_create_players_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('players', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('players');
+    }
+};

--- a/database/migrations/2025_07_10_001726_create_players_table.php
+++ b/database/migrations/2025_07_10_001726_create_players_table.php
@@ -13,6 +13,10 @@ return new class extends Migration
     {
         Schema::create('players', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->foreignId('team_id')->constrained()->onDelete('cascade');
+            $table->integer('number')->nullable();
+            $table->string('photo_url')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_10_003431_create_player_position_table.php
+++ b/database/migrations/2025_07_10_003431_create_player_position_table.php
@@ -13,7 +13,8 @@ return new class extends Migration
     {
         Schema::create('player_position', function (Blueprint $table) {
             $table->id();
-            $table->timestamps();
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->foreignId('position_id')->constrained()->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2025_07_10_003431_create_player_position_table.php
+++ b/database/migrations/2025_07_10_003431_create_player_position_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('player_position', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('player_position');
+    }
+};

--- a/database/migrations/2025_07_10_003703_create_batter_stats_table.php
+++ b/database/migrations/2025_07_10_003703_create_batter_stats_table.php
@@ -13,7 +13,16 @@ return new class extends Migration
     {
         Schema::create('batter_stats', function (Blueprint $table) {
             $table->id();
-            $table->timestamps();
+                $table->foreignId('player_id')->constrained()->onDelete('cascade');
+                $table->date('match_date');
+                $table->string('opponent_team');
+                $table->integer('at_bats');
+                $table->integer('hits');
+                $table->integer('home_runs');
+                $table->integer('rbi');
+                $table->integer('strikeouts');
+                $table->integer('walks');
+                $table->timestamp('created_at')->useCurrent();
         });
     }
 

--- a/database/migrations/2025_07_10_003703_create_batter_stats_table.php
+++ b/database/migrations/2025_07_10_003703_create_batter_stats_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('batter_stats', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('batter_stats');
+    }
+};

--- a/database/migrations/2025_07_10_003902_create_pitcher_stats_table.php
+++ b/database/migrations/2025_07_10_003902_create_pitcher_stats_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pitcher_stats', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pitcher_stats');
+    }
+};

--- a/database/migrations/2025_07_10_003902_create_pitcher_stats_table.php
+++ b/database/migrations/2025_07_10_003902_create_pitcher_stats_table.php
@@ -13,7 +13,17 @@ return new class extends Migration
     {
         Schema::create('pitcher_stats', function (Blueprint $table) {
             $table->id();
-            $table->timestamps();
+			$table->foreignId('player_id')->constrained()->onDelete('cascade');
+		    $table->date('match_date');
+		    $table->string('opponent_team');
+		    $table->float('innings_pitched');
+			$table->integer('hits_allowed');
+		    $table->integer('strikeouts');
+		    $table->integer('walks');
+		    $table->integer('earned_runs');
+			$table->boolean('win')->default(false);
+		    $table->boolean('save')->default(false);
+		    $table->timestamp('created_at')->useCurrent();
         });
     }
 

--- a/database/migrations/2025_07_10_004100_create_favorites_table.php
+++ b/database/migrations/2025_07_10_004100_create_favorites_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('favorites', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('favorites');
+    }
+};

--- a/database/migrations/2025_07_10_004100_create_favorites_table.php
+++ b/database/migrations/2025_07_10_004100_create_favorites_table.php
@@ -13,7 +13,9 @@ return new class extends Migration
     {
         Schema::create('favorites', function (Blueprint $table) {
             $table->id();
-            $table->timestamps();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->timestamp('created_at')->useCurrent();
         });
     }
 

--- a/database/migrations/2025_07_10_042207_create_external_api_sources_table.php
+++ b/database/migrations/2025_07_10_042207_create_external_api_sources_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('external_api_sources', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('external_api_sources');
+    }
+};

--- a/database/migrations/2025_07_10_042207_create_external_api_sources_table.php
+++ b/database/migrations/2025_07_10_042207_create_external_api_sources_table.php
@@ -13,7 +13,10 @@ return new class extends Migration
     {
         Schema::create('external_api_sources', function (Blueprint $table) {
             $table->id();
-            $table->timestamps();
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->string('source_name');
+            $table->string('source_url');
+            $table->timestamp('last_synced_at')->nullable();
         });
     }
 

--- a/database/migrations/2025_07_10_042306_add_role_to_users_table.php
+++ b/database/migrations/2025_07_10_042306_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2025_07_10_042306_add_role_to_users_table.php
+++ b/database/migrations/2025_07_10_042306_add_role_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->enum('role', ['user', 'admin'])->default('user');
         });
     }
 


### PR DESCRIPTION
## 概要
- チーム（Team）、ポジション（Position）、選手（Player）、多対多関連（player_position）、打撃成績（BatterStat）、投手成績（PitcherStat）、お気に入り（favorites）、外部API（external_api_sources）に関するモデルおよびマイグレーションファイルを追加
- usersテーブルへroleカラム（user/admin）を追加
- 各マイグレーションのテーブル定義およびリレーションを実装

## 主な変更点
- `php artisan make:model`や`make:migration`で各モデル・テーブル作成
- テーブルの外部キー制約やカラム設計を反映
- `./vendor/bin/sail artisan migrate` で全マイグレーション適用

## 追加・変更されたファイル
- チーム、ポジション、選手、成績などのモデル
- 上記に関するマイグレーションファイル
- usersテーブル roleカラム追加マイグレーション

## 補足
- 今後、コントローラやシーダ、API連携等の実装を予定しています。